### PR TITLE
add fpath entry outside of plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,10 @@ Install it with your favourite zsh package manager, or clone it directly to your
 array in your `.zshrc` file:
 
 ```zsh
-plugins=(... zsh-asdf-direnv)
+export ASDF_DIR="$HOME/.asdf"
+fpath=(${ASDF_DIR}/completions $fpath)
+
+plugins = (... zsh-asdf-direnv)
 ```
 
 ## Usage

--- a/zsh-asdf-direnv.plugin.zsh
+++ b/zsh-asdf-direnv.plugin.zsh
@@ -74,8 +74,6 @@ _zsh_asdf_direnv_install_asdf() {
 
 # source asdf and run the direnv hook, after adding completions to path
 _zsh_asdf_direnv_load() {
-  fpath=(${ASDF_DIR}/completions $fpath)
-
   # if specified only load the asdf wrapper, leaving the shims out of path
   if test "$ZSH_ASDF_DIRENV_LIBONLY" = "true"; then
     PATH="$PATH:$ASDF_DIR/bin"


### PR DESCRIPTION
compinit is called before plugins are loaded. to avoid having to call compinit again after loading this plugin, suggest to set fpath outside of the plugin in zshrc.

see also this issue https://github.com/zsh-users/zsh-completions/issues/603